### PR TITLE
Dependent job submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ The environment variable ```RR_Root``` is required to point to the global instal
 
 ## Usage
 
-To use this extension you need to assign the ```royalrender``` family and have data in the ```royalrenderData``` data member on the instance you want to publish.
+To use this extension you need to assign the ```royalrender``` family and have data in the ```royalrenderData``` or ```royalrenderJobs``` data member on the instance you want to publish.
 
-```royalrenderData``` is an dictionary that gets convert to RoyalRender's xml submission. Please read more about RoyalRender's xml; http://www.royalrender.de/help8/index.html?rrJobsubmitxmlfile.html.   
+### royalrenderData
+```royalrenderData``` is a dictionary that gets convert to RoyalRender's xml submission. Please read more about RoyalRender's xml; http://www.royalrender.de/help8/index.html?rrJobsubmitxmlfile.html.   
 You can also get the xml data from an already submitted job in the rrControl application, by selecting a job and choosing "Jobs" > "Export selected Jobs as .xml".
 
 Exported from rrControl:
@@ -37,4 +38,8 @@ instance.data["royalrenderData"] = {
 }
 ```
 
+### royalrenderJobs
+```royalrenderData``` is a list of dictionaries to support submitting multiple jobs.
+
+### Submission UI
 You can also force the showing of the submission UI, by checking the ```Display Royal Render Submitter``` plugin.


### PR DESCRIPTION
**Motivation**

In order to support dependent job submissions, this package needs to support multiple jobs.

**Changes**

- Support multiple jobs submission.
- Order jobs by PreID for job dependency support.
- Better debug output by using rrSubmitterConsole directly.